### PR TITLE
fix: correct export path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "default": "dist/index.js",
-      "types": "dist/index.d.ts"
+      "default": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
This fixes module not found: Error: Invalid "exports" target "dist/index.js" defined for "."